### PR TITLE
Fix roxygen2 issue with all/all.equal ambiguity

### DIFF
--- a/R/all.equal.R
+++ b/R/all.equal.R
@@ -21,7 +21,8 @@
 
 
 #' @title Global Comparison of two (or more) dendrograms
-#' @export
+#' @exportS3Method all.equal dendlist
+#' @method all.equal dendlist
 #' @aliases
 #' all.equal.dendlist
 #' @description


### PR DESCRIPTION
You are affected by https://github.com/r-lib/roxygen2/issues/1587. Came across your package while trying to find a solution for my own, so sharing what I found.