### PR TITLE
Added tests for pvclust.R

### DIFF
--- a/R/pvclust.R
+++ b/R/pvclust.R
@@ -73,7 +73,8 @@ na_locf <- function(x, first_na_value = 0, recursive = TRUE, ...) {
   } else {
     # If the first observation is NA, fill it with "first_na_value"
     if (x_na[1]) x[1] <- first_na_value
-
+    x_na[1] <- F
+    
     x_na_loc <- which(x_na)
     x[x_na_loc] <- x[x_na_loc - 1]
 

--- a/tests/testthat/test-pvclust_extract.R
+++ b/tests/testthat/test-pvclust_extract.R
@@ -4,10 +4,54 @@ test_that("extract au", {
   suppressWarnings(RNGversion("3.5.0"))
   library(pvclust)
   set.seed(123)
-  suppressWarnings(dend <- USArrests[1:5, ] %>% pvclust())
+  capture.output(suppressWarnings(dend <- USArrests[1:5, ] %>% pvclust()))
   # plot(dend)
   # pvclust_edges(dend)
   expect_identical(as.character(pvclust_edges(dend)[, 1]), c("Assault", "UrbanPop", "Murder"))
   expect_identical(as.character(pvclust_edges(dend)[, 2]), c("Rape", "1", "2"))
   # expect_identical(round(pvclust_edges(dend)[, 3], digits = 2), c(0.97, 1.00, 1.00)) # there is a stochastic element to the outcome so while it works using test_that it may be causing error with travis-ci checks
+})
+
+
+test_that("na_locf works", {
+   
+   # replace NA values with value prior to it
+   x <- c(NA,1,2,NA,4,NA,6)
+   result <- na_locf(x)
+   expect_identical(result, c(0,1,2,2,4,4,6))
+   
+   result <- na_locf(x, recursive = F)
+   expect_identical(result, c(0,1,2,2,4,4,6))
+   
+})
+
+
+test_that("text.pvclust works", {
+   
+   # add same text to dendrogram object as normally comes with pvclust
+   suppressWarnings(RNGversion("3.5.0"))
+   library(pvclust)
+   set.seed(123)
+   capture.output(suppressWarnings(dend <- mtcars[1:5, ] %>% pvclust()))
+   
+   plot(as.dendrogram(dend))
+   expect_no_error(
+      text.pvclust(dend)
+   )
+
+})
+
+
+test_that("pvrect2 works", {
+   
+   # add same text to dendrogram object as normally comes with pvclust
+   suppressWarnings(RNGversion("3.5.0"))
+   library(pvclust)
+   set.seed(123)
+   capture.output(suppressWarnings(dend <- mtcars[1:5, ] %>% pvclust()))
+   
+   plot(as.dendrogram(dend))
+   expect_no_error(
+      pvrect2(dend)
+   )
 })

--- a/tests/testthat/test-pvclust_extract.R
+++ b/tests/testthat/test-pvclust_extract.R
@@ -52,7 +52,19 @@ test_that("pvrect2 works", {
    
    plot(as.dendrogram(dend))
    expect_no_error(
-      pvrect2(dend)
+      pvrect2(dend, type = "geq")
+   )
+   expect_no_error(
+      pvrect2(dend, type = "leq")
+   )
+   expect_no_error(
+      pvrect2(dend, type = "gt")
+   )
+   expect_no_error(
+      pvrect2(dend, type = "lt")
+   )
+   expect_error(
+      pvrect2(dend, type = NA)
    )
 })
 

--- a/tests/testthat/test-pvclust_extract.R
+++ b/tests/testthat/test-pvclust_extract.R
@@ -100,7 +100,7 @@ test_that("strwidth2 works", {
    capture.output(suppressWarnings(dend <- mtcars[1:5, ] %>% pvclust()))
    
    expect_true(
-      is.numeric(strwidth2(result))
+      is.numeric(strwidth2(dend))
    )
    
 })

--- a/tests/testthat/test-pvclust_extract.R
+++ b/tests/testthat/test-pvclust_extract.R
@@ -44,7 +44,7 @@ test_that("text.pvclust works", {
 
 test_that("pvrect2 works", {
    
-   # add same text to dendrogram object as normally comes with pvclust
+   # add rect dendrogram object to highlight consistent clusters
    suppressWarnings(RNGversion("3.5.0"))
    library(pvclust)
    set.seed(123)
@@ -54,4 +54,21 @@ test_that("pvrect2 works", {
    expect_no_error(
       pvrect2(dend)
    )
+})
+
+
+test_that("pvclust_show_signif works", {
+   
+   # color brnaches to highlight consistent clusters
+   suppressWarnings(RNGversion("3.5.0"))
+   library(pvclust)
+   data(lung) # 916 genes for 73 subjects
+   set.seed(13134)
+   result <- pvclust(lung[, 1:20], method.dist = "cor", method.hclust = "average", nboot = 100)
+   dend <- as.dendrogram(result)
+   
+   expect_no_error(
+      pvclust_show_signif_gradient(dend, result) %>% plot() 
+   )
+     
 })

--- a/tests/testthat/test-pvclust_extract.R
+++ b/tests/testthat/test-pvclust_extract.R
@@ -89,3 +89,19 @@ test_that("pvclust_show_signif_gradient works", {
    )
    
 })
+
+
+test_that("strwidth2 works", {
+   
+   # test that adjusted string widths are numeric
+   suppressWarnings(RNGversion("3.5.0"))
+   library(pvclust)
+   data(lung) # 916 genes for 73 subjects
+   set.seed(13134)
+   capture.output(result <- pvclust(lung[, 1:20], method.dist = "cor", method.hclust = "average", nboot = 100))
+   
+   expect_true(
+      is.numeric(strwidth2(result))
+   )
+   
+})

--- a/tests/testthat/test-pvclust_extract.R
+++ b/tests/testthat/test-pvclust_extract.R
@@ -96,12 +96,43 @@ test_that("strwidth2 works", {
    # test that adjusted string widths are numeric
    suppressWarnings(RNGversion("3.5.0"))
    library(pvclust)
-   data(lung) # 916 genes for 73 subjects
-   set.seed(13134)
-   capture.output(result <- pvclust(lung[, 1:20], method.dist = "cor", method.hclust = "average", nboot = 100))
+   set.seed(123)
+   capture.output(suppressWarnings(dend <- mtcars[1:5, ] %>% pvclust()))
    
    expect_true(
       is.numeric(strwidth2(result))
+   )
+   
+})
+
+
+test_that("as.hclust.pvclust works", {
+   
+   library(pvclust)
+   set.seed(123)
+   capture.output(suppressWarnings(dend <- mtcars[1:5, ] %>% pvclust()))
+   result <- as.hclust.pvclust(dend)
+   
+   # should convert pvclust to hclust object
+   expect_identical(
+      attributes(result)$class,
+      "hclust"
+   )
+   
+})
+
+
+test_that("as.dendrogram.pvclust works", {
+   
+   library(pvclust)
+   set.seed(123)
+   capture.output(suppressWarnings(dend <- mtcars[1:5, ] %>% pvclust()))
+   result <- as.dendrogram.pvclust(dend)
+   
+   # should convert pvclust to hclust object
+   expect_identical(
+      attributes(result)$class,
+      "dendrogram"
    )
    
 })

--- a/tests/testthat/test-pvclust_extract.R
+++ b/tests/testthat/test-pvclust_extract.R
@@ -59,16 +59,33 @@ test_that("pvrect2 works", {
 
 test_that("pvclust_show_signif works", {
    
-   # color brnaches to highlight consistent clusters
+   # bold branches to highlight consistent clusters
    suppressWarnings(RNGversion("3.5.0"))
    library(pvclust)
    data(lung) # 916 genes for 73 subjects
    set.seed(13134)
-   result <- pvclust(lung[, 1:20], method.dist = "cor", method.hclust = "average", nboot = 100)
+   capture.output(result <- pvclust(lung[, 1:20], method.dist = "cor", method.hclust = "average", nboot = 100))
+   dend <- as.dendrogram(result)
+   
+   expect_no_error(
+      pvclust_show_signif(dend, result) %>% plot() 
+   )
+     
+})
+
+
+test_that("pvclust_show_signif_gradient works", {
+   
+   # color branches to highlight consistent clusters
+   suppressWarnings(RNGversion("3.5.0"))
+   library(pvclust)
+   data(lung) # 916 genes for 73 subjects
+   set.seed(13134)
+   capture.output(result <- pvclust(lung[, 1:20], method.dist = "cor", method.hclust = "average", nboot = 100))
    dend <- as.dendrogram(result)
    
    expect_no_error(
       pvclust_show_signif_gradient(dend, result) %>% plot() 
    )
-     
+   
 })


### PR DESCRIPTION
Fixed bug in na_locf too. Previously, inputting a vector with a starting NA value and any subsequent non-NA values would create an error. For example, this would not work: 
`vec <- c(NA, 1, 2)
na_locf(vec)`